### PR TITLE
made udpates to following: mistral v3 from v2, updated torch librarie…

### DIFF
--- a/.project-metadata.yaml
+++ b/.project-metadata.yaml
@@ -13,7 +13,7 @@ environment_variables:
 
 runtimes: 
   - editor: Workbench
-    kernel: Python 3.9
+    kernel: Python 3.10
     edition: Nvidia GPU
   
 tasks:

--- a/Launch_model.py
+++ b/Launch_model.py
@@ -6,6 +6,8 @@ import torch
 import cml.metrics_v1 as metrics
 import cml.models_v1 as models
 
+import sentencepiece
+
 hf_access_token = os.environ.get('HF_ACCESS_TOKEN')
 
 # Quantization
@@ -20,7 +22,7 @@ bnb_config = BitsAndBytesConfig(
 )
 
 # Create a model object with above parameters
-model_name = "mistralai/Mistral-7B-Instruct-v0.2"
+model_name = "mistralai/Mistral-7B-Instruct-v0.3"
 
 model = AutoModelForCausalLM.from_pretrained(
     model_name, 
@@ -41,7 +43,15 @@ def opt_args_value(args, arg_name, default):
     return default
 
 # Define tokenizer parameters
-tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True, token=hf_access_token)
+
+
+tokenizer = AutoTokenizer.from_pretrained(
+    model_name,
+    trust_remote_code=True,
+    token=hf_access_token,
+    use_fast=True  # Explicitly request the fast tokenizer
+)
+
 tokenizer.pad_token = tokenizer.eos_token
 
 # Mamke the call to 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Deploy the model by:
   }
    ```
 - Pick Runtime
-  - PBJ Workbench -- Python 3.9 -- Nvidia GPU -- 2023.08
+  - Jupyterlab -- Python 3.10 -- Nvidia GPU -- 2024.10
 - Set Resource Profile
   - At least 4CPU / 16MEM
   - 1 GPU

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,15 @@
-setuptools==58.1.0
-bitsandbytes
+# PyTorch and related packages
+--find-links https://download.pytorch.org/whl/cu121
+torch==2.1.0
+torchvision==0.16.0
+torchaudio==2.1.0
+
+sentencepiece
+
+# Reset to default PyPI index for other packages
+--index-url https://pypi.org/simple
+
+# Transformers and supporting libraries
+transformers
 accelerate
-scipy==1.11.1
-#transformers
-git+https://github.com/huggingface/peft.git@0b62b4378b4ce9367932c73540349da9a41bdea8
-git+https://github.com/huggingface/transformers
+bitsandbytes


### PR DESCRIPTION
# Updates for AWS CUDA Compatibility and Model Version

This PR updates the repository to work with current AWS GPU instances by:

1. Upgrading to Mistral-7B-Instruct-v0.3 from v0.2
2. Updating PyTorch dependencies to use CUDA 12.1
3. Updating Python runtime from 3.9 to 3.10
4. Optimizing tokenizer configuration by explicitly enabling fast tokenization
5. Adding necessary dependencies in requirements.txt for better compatibility

These changes resolve compatibility issues with current AWS GPU instances while maintaining full functionality. All changes have been tested on AWS GPU instances.

Testing Environment:
- AWS GPU Instance
- Python 3.10
- CUDA 12.1
- Jupyterlab 2024.10